### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Flutter plugin for the [InMobi](https://github.com/InMobi) advertising SDK.
 Add the following to your dependencies:
 
 ```
-inmobi_sdk: 
+inmobi_sdk_plugin: 
   git:
     url: git://github.com/nmfisher/inmobi_flutter_plugin
 ```


### PR DESCRIPTION
Fixes the incorrect mentioned name of the plugin mentioned in the Readme for the installation of the plugin.
Updated this:
```
inmobi_sdk: 
  git:
    url: git://github.com/nmfisher/inmobi_flutter_plugin
```
To
```
inmobi_sdk_plugin: 
  git:
    url: git://github.com/nmfisher/inmobi_flutter_plugin
```